### PR TITLE
Update confluent client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,9 +35,9 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1")
 
-    implementation("io.confluent:kafka-schema-registry-client:6.0.1")
-    implementation("io.confluent:kafka-protobuf-serializer:6.0.1")
-    implementation("io.confluent:kafka-json-schema-serializer:6.0.1")
+    implementation("io.confluent:kafka-schema-registry-client:7.1.1")
+    implementation("io.confluent:kafka-protobuf-serializer:7.1.1")
+    implementation("io.confluent:kafka-json-schema-serializer:7.1.1")
     implementation("com.github.everit-org.json-schema:org.everit.json.schema:1.12.1")
 
     implementation("io.github.java-diff-utils:java-diff-utils:4.11")


### PR DESCRIPTION
Current pull request should fix this https://github.com/domnikl/schema-registry-gitops/issues/27 issue. 

Karapace returns `"compatibility": "BACKWARD"` field in the response for schema. And schema registry client switched to ignore unknown properties in this [pull request](https://github.com/confluentinc/schema-registry/commit/4b79983bb6aebd5bc7f56870a59790ced6331cb9#diff-8c3044f23b26d37cfcf89dd6f1248276ea1ebe4de074cd68e1c749f7c0dd7067) 