### PR TITLE
#30 allow usage of multiple input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ Manages schema registries through Infrastructure as Code
   -v, --verbose              enable verbose logging
   -V, --version              Print version information and exit.
 Commands:
-  help   Displays help information about the specified command
-  plan   validate and plan schema changes, can be used to see all pending
-           changes
   apply  applies the state to the given schema registry
   dump   prints the current state
+  plan   validate and plan schema changes, can be used to see all pending
+           changes
 ```
 
 In order to get help for a specific command, try `schema-registry-gitops <command> -h`.
@@ -45,14 +44,14 @@ In order to get help for a specific command, try `schema-registry-gitops <comman
 `schema-registry-gitops` is available through [Docker Hub](https://hub.docker.com/repository/docker/domnikl/schema-registry-gitops), so running it in a container is as easy as:
 
 ```sh
-docker run -v "$(pwd)/examples":/data domnikl/schema-registry-gitops plan --properties /data/client.properties /data/schema-registry.yml
+docker run -v "$(pwd)/examples":/data domnikl/schema-registry-gitops plan --properties /data/client.properties /data/base.yml
 ```
 
 Please keep in mind that using a tagged release may be a good idea.
 
-## State file
+## State files
 
-The desired state is managed using this YAML schema:
+The desired state is managed using the following YAML schema:
 
 ```yaml
 # sets global compatibility level (optional)
@@ -87,6 +86,8 @@ subjects:
         }'
     type: PROTOBUF
 ```
+
+When using multiple files, the state is the merge result of those. Keep in mind that later references of the same subject names will overwrite earlier definitions.
 
 ### compatibility
 
@@ -165,7 +166,7 @@ Docker is used to build and test `schema-registry-gitops` for development.
 docker build -t domnikl/schema-registry-gitops .
 
 # run it in Docker
-docker run -v ./examples:/data domnikl/schema-registry-gitops plan --registry http://localhost:8081 /data/schema-registry.yml
+docker run -v ./examples:/data domnikl/schema-registry-gitops plan --registry http://localhost:8081 /data/base.yml /data/with_references.yml
 ```
 
 ## Acknowledgement

--- a/examples/base.yml
+++ b/examples/base.yml
@@ -15,11 +15,3 @@ subjects:
   - name: json-schema-value
     file: foo.json
     type: JSON
-
-  - name: with-references
-    file: with-references.avsc
-    type: AVRO
-    references:
-      - name: dev.domnikl.schema_registry_gitops.User
-        subject: User-value
-        version: 1

--- a/examples/with_references.yml
+++ b/examples/with_references.yml
@@ -1,0 +1,13 @@
+subjects:
+  - name: with-references
+    file: with-references.avsc
+    type: AVRO
+    references:
+      - name: dev.domnikl.schema_registry_gitops.User
+        subject: User-value
+        version: 1
+
+  - name: User-value
+    file: foo.json
+    type: JSON
+    compatibility: BACKWARD

--- a/src/main/kotlin/dev/domnikl/schema_registry_gitops/State.kt
+++ b/src/main/kotlin/dev/domnikl/schema_registry_gitops/State.kt
@@ -6,6 +6,16 @@ data class State(val compatibility: Compatibility?, val subjects: List<Subject>)
 
         require(duplicates.isEmpty()) { "State in YAML configuration is invalid: duplicated subject(s) '${duplicates.joinToString("', '")}' found" }
     }
+
+    fun merge(other: State): State {
+        val a = subjects.associateBy { it.name }
+        val b = other.subjects.associateBy { it.name }
+
+        return State(
+            compatibility ?: other.compatibility,
+            (a + b).map { it.value }
+        )
+    }
 }
 
 private fun <T, K> List<T>.duplicatesBy(f: (T) -> K): List<K> {

--- a/src/main/kotlin/dev/domnikl/schema_registry_gitops/State.kt
+++ b/src/main/kotlin/dev/domnikl/schema_registry_gitops/State.kt
@@ -11,10 +11,7 @@ data class State(val compatibility: Compatibility?, val subjects: List<Subject>)
         val a = subjects.associateBy { it.name }
         val b = other.subjects.associateBy { it.name }
 
-        return State(
-            compatibility ?: other.compatibility,
-            (a + b).map { it.value }
-        )
+        return State(other.compatibility ?: compatibility, (a + b).map { it.value })
     }
 }
 

--- a/src/main/kotlin/dev/domnikl/schema_registry_gitops/cli/Apply.kt
+++ b/src/main/kotlin/dev/domnikl/schema_registry_gitops/cli/Apply.kt
@@ -27,8 +27,8 @@ class Apply(
     @CommandLine.ParentCommand
     private lateinit var cli: CLI
 
-    @CommandLine.Parameters(description = ["path to input YAML file"])
-    private lateinit var inputFile: File
+    @CommandLine.Parameters(description = ["path to input YAML files"])
+    private lateinit var inputFiles: List<File>
 
     @CommandLine.Option(
         names = ["-d", "--enable-deletes"],
@@ -43,12 +43,14 @@ class Apply(
             val diffing = diffing ?: Diffing(configuration.schemaRegistryClient())
             val applier = applier ?: Applier(configuration.schemaRegistryClient(), logger)
 
-            val state = persistence.load(inputFile.absoluteFile.parentFile, inputFile.absoluteFile)
+            val state = persistence.load(inputFiles.first().absoluteFile.parentFile, inputFiles.map { it.absoluteFile })
             val diff = diffing.diff(state, enableDeletes)
 
             applier.apply(diff)
 
-            logger.info("[SUCCESS] Applied state from $inputFile to ${configuration.baseUrl}")
+            inputFiles.forEach {
+                logger.info("[SUCCESS] Applied state from $it to ${configuration.baseUrl}")
+            }
 
             0
         } catch (e: Exception) {

--- a/src/main/kotlin/dev/domnikl/schema_registry_gitops/cli/Plan.kt
+++ b/src/main/kotlin/dev/domnikl/schema_registry_gitops/cli/Plan.kt
@@ -30,8 +30,8 @@ class Plan(
     @ParentCommand
     private lateinit var cli: CLI
 
-    @Parameters(description = ["path to input YAML file"])
-    private lateinit var inputFile: File
+    @Parameters(description = ["path to input YAML files"])
+    private lateinit var inputFiles: List<File>
 
     @Option(
         names = ["-d", "--enable-deletes"],
@@ -45,7 +45,7 @@ class Plan(
             val persistence = persistence ?: Persistence(configuration.client(), logger)
             val diffing = diffing ?: Diffing(configuration.schemaRegistryClient())
 
-            val state = persistence.load(inputFile.absoluteFile.parentFile, inputFile.absoluteFile)
+            val state = persistence.load(inputFiles.first().absoluteFile.parentFile, inputFiles.map { it.absoluteFile })
             val result = diffing.diff(state, enableDeletes)
 
             if (!result.isEmpty()) {

--- a/src/test/kotlin/dev/domnikl/schema_registry_gitops/StateTest.kt
+++ b/src/test/kotlin/dev/domnikl/schema_registry_gitops/StateTest.kt
@@ -1,5 +1,6 @@
 package dev.domnikl.schema_registry_gitops
 
+import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.mockk.mockk
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -21,25 +22,41 @@ class StateTest {
 
     @Test
     fun `can merge two states`() {
+        val schema1 = mockk<ParsedSchema>()
+        val schema2 = mockk<ParsedSchema>()
+        val schema3 = mockk<ParsedSchema>()
+        val schema4 = mockk<ParsedSchema>()
+
         val a = State(
             null,
             listOf(
-                Subject("abc", null, mockk()),
-                Subject("foo", Compatibility.BACKWARD, mockk())
+                Subject("abc", null, schema1),
+                Subject("foo", Compatibility.BACKWARD, schema2)
             )
         )
 
         val b = State(
             Compatibility.BACKWARD,
             listOf(
-                Subject("foo", null, mockk()),
-                Subject("bar", null, mockk())
+                Subject("foo", null, schema3),
+                Subject("bar", null, schema4)
             )
         )
 
         val merged = a.merge(b)
 
+        assertEquals(Compatibility.BACKWARD, merged.compatibility)
         assertEquals(listOf("abc", "foo", "bar"), merged.subjects.map { it.name })
         assertEquals(listOf(null, null, null), merged.subjects.map { it.compatibility })
+        assertEquals(listOf(schema1, schema3, schema4), merged.subjects.map { it.schema })
+    }
+
+    @Test
+    fun `can merge and keep latest global compatibility`() {
+        val a = State(Compatibility.FORWARD, emptyList())
+        val b = State(Compatibility.BACKWARD, emptyList())
+
+        assertEquals(Compatibility.BACKWARD, a.merge(b).compatibility)
+        assertEquals(Compatibility.FORWARD, b.merge(a).compatibility)
     }
 }

--- a/src/test/kotlin/dev/domnikl/schema_registry_gitops/StateTest.kt
+++ b/src/test/kotlin/dev/domnikl/schema_registry_gitops/StateTest.kt
@@ -2,6 +2,7 @@ package dev.domnikl.schema_registry_gitops
 
 import io.mockk.mockk
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
 
 class StateTest {
@@ -16,5 +17,29 @@ class StateTest {
                 )
             )
         }
+    }
+
+    @Test
+    fun `can merge two states`() {
+        val a = State(
+            null,
+            listOf(
+                Subject("abc", null, mockk()),
+                Subject("foo", Compatibility.BACKWARD, mockk())
+            )
+        )
+
+        val b = State(
+            Compatibility.BACKWARD,
+            listOf(
+                Subject("foo", null, mockk()),
+                Subject("bar", null, mockk())
+            )
+        )
+
+        val merged = a.merge(b)
+
+        assertEquals(listOf("abc", "foo", "bar"), merged.subjects.map { it.name })
+        assertEquals(listOf(null, null, null), merged.subjects.map { it.compatibility })
     }
 }

--- a/src/test/kotlin/dev/domnikl/schema_registry_gitops/cli/PlanTest.kt
+++ b/src/test/kotlin/dev/domnikl/schema_registry_gitops/cli/PlanTest.kt
@@ -42,7 +42,7 @@ class PlanTest {
         every { persistence.load(any(), input) } returns state
         every { diffing.diff(any()) } returns Diffing.Result(compatibility = Diffing.Change(Compatibility.NONE, Compatibility.BACKWARD))
 
-        val exitCode = commandLine.execute("plan", "--registry", "https://foo.bar", input.path)
+        val exitCode = commandLine.execute("plan", "--registry", "https://foo.bar", *input.map { it.path }.toTypedArray())
 
         assertEquals(0, exitCode)
 
@@ -67,7 +67,7 @@ class PlanTest {
         every { persistence.load(any(), input) } returns state
         every { diffing.diff(any()) } returns Diffing.Result()
 
-        val exitCode = commandLine.execute("plan", "--registry", "https://foo.bar", input.path)
+        val exitCode = commandLine.execute("plan", "--registry", "https://foo.bar", *input.map { it.path }.toTypedArray())
 
         assertEquals(0, exitCode)
 
@@ -89,7 +89,7 @@ class PlanTest {
         every { persistence.load(any(), input) } returns state
         every { diffing.diff(any(), true) } returns Diffing.Result(deleted = listOf("foobar"))
 
-        val exitCode = commandLine.execute("plan", "--enable-deletes", "--registry", "https://foo.bar", input.path)
+        val exitCode = commandLine.execute("plan", "--enable-deletes", "--registry", "https://foo.bar", *input.map { it.path }.toTypedArray())
 
         assertEquals(0, exitCode)
 
@@ -116,7 +116,7 @@ class PlanTest {
         every { persistence.load(any(), input) } returns state
         every { diffing.diff(any()) } returns Diffing.Result(added = state.subjects)
 
-        val exitCode = commandLine.execute("plan", "--registry", "https://foo.bar", input.path)
+        val exitCode = commandLine.execute("plan", "--registry", "https://foo.bar", *input.map { it.path }.toTypedArray())
 
         assertEquals(0, exitCode)
 
@@ -154,7 +154,7 @@ class PlanTest {
             )
         )
 
-        val exitCode = commandLine.execute("plan", "--registry", "https://foo.bar", input.path)
+        val exitCode = commandLine.execute("plan", "--registry", "https://foo.bar", *input.map { it.path }.toTypedArray())
 
         verify {
             logger.info("The following changes would be applied:")
@@ -203,7 +203,7 @@ class PlanTest {
         every { persistence.load(any(), input) } returns state
         every { diffing.diff(any()) } returns Diffing.Result(incompatible = state.subjects)
 
-        val exitCode = commandLine.execute("plan", "--registry", "foo", input.path)
+        val exitCode = commandLine.execute("plan", "--registry", "foo", *input.map { it.path }.toTypedArray())
 
         assertEquals(1, exitCode)
 
@@ -226,12 +226,12 @@ class PlanTest {
         every { diffing.diff(any()) } throws IllegalArgumentException("foobar")
 
         val input = fromResources("with_inline_schema.yml")
-        val exitCode = commandLine.execute("plan", "--registry", "foo", input.path)
+        val exitCode = commandLine.execute("plan", "--registry", "foo", *input.map { it.path }.toTypedArray())
 
         assertEquals(2, exitCode)
 
         verify { logger.error("java.lang.IllegalArgumentException: foobar") }
     }
 
-    private fun fromResources(name: String) = File(javaClass.classLoader.getResource(name)!!.toURI())
+    private fun fromResources(name: String) = listOf(File(javaClass.classLoader.getResource(name)!!.toURI()))
 }


### PR DESCRIPTION
This will allow users to specify multiple input files which will get merged into one `State` instance. Later references to the same subject name will overwrite earlier ones. Also global compatibility will overwritten later on (except if it is `null`).