### PR TITLE
#100 log verbose diagnostics from schema registry

### DIFF
--- a/src/main/kotlin/dev/domnikl/schemaregistrygitops/SchemaRegistryClient.kt
+++ b/src/main/kotlin/dev/domnikl/schemaregistrygitops/SchemaRegistryClient.kt
@@ -27,12 +27,12 @@ class SchemaRegistryClient(private val client: CachedSchemaRegistryClient) {
         return Compatibility.valueOf(client.updateCompatibility(subject.name, subject.compatibility.toString()))
     }
 
-    fun testCompatibility(subject: Subject): Boolean {
+    fun testCompatibility(subject: Subject): List<String> {
         return handleNotExisting {
             handleUnsupportedSchemaType {
-                client.testCompatibility(subject.name, subject.schema)
+                client.testCompatibilityVerbose(subject.name, subject.schema)
             }
-        } ?: true
+        }?.toList() ?: emptyList()
     }
 
     fun getLatestSchema(subject: String): ParsedSchema {

--- a/src/main/kotlin/dev/domnikl/schemaregistrygitops/cli/Apply.kt
+++ b/src/main/kotlin/dev/domnikl/schemaregistrygitops/cli/Apply.kt
@@ -5,6 +5,7 @@ import dev.domnikl.schemaregistrygitops.Configuration
 import dev.domnikl.schemaregistrygitops.state.Applier
 import dev.domnikl.schemaregistrygitops.state.Diffing
 import dev.domnikl.schemaregistrygitops.state.Persistence
+import dev.domnikl.schemaregistrygitops.state.Result
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import picocli.CommandLine
@@ -46,13 +47,15 @@ class Apply(
             val state = persistence.load(inputFiles.first().absoluteFile.parentFile, inputFiles.map { it.absoluteFile })
             val diff = diffing.diff(state, enableDeletes)
 
-            applier.apply(diff)
+            if (applier.apply(diff) == Result.SUCCESS) {
+                inputFiles.forEach {
+                    logger.info("[SUCCESS] Applied state from $it to ${configuration.baseUrl}")
+                }
 
-            inputFiles.forEach {
-                logger.info("[SUCCESS] Applied state from $it to ${configuration.baseUrl}")
+                0
+            } else {
+                1
             }
-
-            0
         } catch (e: Exception) {
             logger.error(e.toString())
 

--- a/src/main/kotlin/dev/domnikl/schemaregistrygitops/cli/Plan.kt
+++ b/src/main/kotlin/dev/domnikl/schemaregistrygitops/cli/Plan.kt
@@ -94,10 +94,13 @@ class Plan(
             }
 
             if (result.incompatible.isNotEmpty()) {
-                logger.error(
-                    "[ERROR] The following schemas are incompatible with an earlier version: " +
-                        "'${result.incompatible.joinToString("', '") { it.name }}'"
-                )
+                result.incompatible.forEach {
+                    logger.error(
+                        "[ERROR] The following schema is incompatible with an earlier version: '${ it.subject.name }': '" +
+                            it.messages.joinToString(",") +
+                            "'"
+                    )
+                }
 
                 return 1
             }

--- a/src/test/kotlin/dev/domnikl/schemaregistrygitops/SchemaRegistryClientTest.kt
+++ b/src/test/kotlin/dev/domnikl/schemaregistrygitops/SchemaRegistryClientTest.kt
@@ -7,7 +7,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.jupiter.api.assertThrows
@@ -98,57 +97,57 @@ class SchemaRegistryClientTest {
         val schema = mockk<ParsedSchema>()
         val subject = Subject("foo", Compatibility.FORWARD, schema)
 
-        every { client.testCompatibility("foo", schema) } returns true
+        every { client.testCompatibilityVerbose("foo", schema) } returns listOf("hello", "world")
 
-        assert(wrapper.testCompatibility(subject))
+        assertEquals(listOf("hello", "world"), wrapper.testCompatibility(subject))
     }
 
     @Test
-    fun `test compatibility returns true if subject is new`() {
+    fun `test compatibility returns empty list if subject is new`() {
         val schema = mockk<ParsedSchema>()
         val subject = Subject("foo", null, schema)
 
-        every { client.testCompatibility("foo", schema) } throws RestClientException("", 404, 40401)
+        every { client.testCompatibilityVerbose("foo", schema) } throws RestClientException("", 404, 40401)
 
-        assert(wrapper.testCompatibility(subject))
+        assertEquals(emptyList<String>(), wrapper.testCompatibility(subject))
     }
 
     @Test
-    fun `test compatibility returns true if version is new`() {
+    fun `test compatibility returns empty list if version is new`() {
         val schema = mockk<ParsedSchema>()
         val subject = Subject("foo", null, schema)
 
-        every { client.testCompatibility("foo", schema) } throws RestClientException("", 404, 40402)
+        every { client.testCompatibilityVerbose("foo", schema) } throws RestClientException("", 404, 40402)
 
-        assert(wrapper.testCompatibility(subject))
+        assertEquals(emptyList<String>(), wrapper.testCompatibility(subject))
     }
 
     @Test
-    fun `test compatibility returns true if schema is new`() {
+    fun `test compatibility returns empty list if schema is new`() {
         val schema = mockk<ParsedSchema>()
         val subject = Subject("foo", null, schema)
 
-        every { client.testCompatibility("foo", schema) } throws RestClientException("", 404, 40403)
+        every { client.testCompatibilityVerbose("foo", schema) } throws RestClientException("", 404, 40403)
 
-        assert(wrapper.testCompatibility(subject))
+        assertEquals(emptyList<String>(), wrapper.testCompatibility(subject))
     }
 
     @Test
-    fun `test compatibility returns false if client returns false`() {
+    fun `test compatibility returns messages if client returns them`() {
         val schema = mockk<ParsedSchema>()
         val subject = Subject("foo", null, schema)
 
-        every { client.testCompatibility("foo", schema) } returns false
+        every { client.testCompatibilityVerbose("foo", schema) } returns emptyList()
 
-        assertFalse(wrapper.testCompatibility(subject))
+        assertEquals(emptyList<String>(), wrapper.testCompatibility(subject))
     }
 
     @Test
-    fun `test compatibility throws exception if schema type is not supported`() {
+    fun `test compatibility verbose throws exception if schema type is not supported`() {
         val schema = mockk<ParsedSchema>()
         val subject = Subject("foo", null, schema)
 
-        every { client.testCompatibility("foo", schema) } throws RestClientException("", 422, 422)
+        every { client.testCompatibilityVerbose("foo", schema) } throws RestClientException("", 422, 422)
 
         assertThrows<ServerVersionMismatchException> {
             wrapper.testCompatibility(subject)

--- a/src/test/kotlin/dev/domnikl/schemaregistrygitops/cli/ApplyTest.kt
+++ b/src/test/kotlin/dev/domnikl/schemaregistrygitops/cli/ApplyTest.kt
@@ -7,6 +7,7 @@ import dev.domnikl.schemaregistrygitops.fromResources
 import dev.domnikl.schemaregistrygitops.state.Applier
 import dev.domnikl.schemaregistrygitops.state.Diffing
 import dev.domnikl.schemaregistrygitops.state.Persistence
+import dev.domnikl.schemaregistrygitops.state.Result
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -33,7 +34,7 @@ class ApplyTest {
 
         every { configuration.baseUrl } returns "https://foo.bar"
         every { persistence.load(any(), any()) } returns state
-        every { applier.apply(any()) } just runs
+        every { applier.apply(any()) } returns Result.SUCCESS
         every { logger.info(any()) } just runs
         every { diffing.diff(state, false) } returns diffingResult
 
@@ -48,7 +49,7 @@ class ApplyTest {
     @Test
     fun `can handle relative inputFile paths`() {
         every { persistence.load(any(), any()) } throws IllegalArgumentException("foobar")
-        every { applier.apply(any()) } just runs
+        every { applier.apply(any()) } returns Result.ERROR
         every { logger.error(any()) } just runs
 
         val input = "only_compatibility.yml"
@@ -62,7 +63,7 @@ class ApplyTest {
     @Test
     fun `logs errors it encounters`() {
         every { persistence.load(any(), any()) } throws IllegalArgumentException("foobar")
-        every { applier.apply(any()) } just runs
+        every { applier.apply(any()) } returns Result.ERROR
         every { logger.error(any()) } just runs
 
         val input = fromResources("only_compatibility.yml")

--- a/src/test/kotlin/dev/domnikl/schemaregistrygitops/cli/PlanTest.kt
+++ b/src/test/kotlin/dev/domnikl/schemaregistrygitops/cli/PlanTest.kt
@@ -203,14 +203,14 @@ class PlanTest {
         val input = fromResources("with_inline_schema.yml")
 
         every { persistence.load(any(), input) } returns state
-        every { diffing.diff(any()) } returns Diffing.Result(incompatible = state.subjects)
+        every { diffing.diff(any()) } returns Diffing.Result(incompatible = listOf(Diffing.CompatibilityTestResult(state.subjects[0], listOf("my message"))))
 
         val exitCode = commandLine.execute("plan", "--registry", "foo", *input.map { it.path }.toTypedArray())
 
         assertEquals(1, exitCode)
 
         verifyOrder {
-            logger.error("[ERROR] The following schemas are incompatible with an earlier version: 'foo', 'bar'")
+            logger.error("[ERROR] The following schema is incompatible with an earlier version: 'foo': 'my message'")
         }
     }
 

--- a/src/test/kotlin/dev/domnikl/schemaregistrygitops/state/ApplierTest.kt
+++ b/src/test/kotlin/dev/domnikl/schemaregistrygitops/state/ApplierTest.kt
@@ -12,8 +12,8 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import io.mockk.verifyOrder
+import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.jupiter.api.assertThrows
 import org.slf4j.Logger
 
 class ApplierTest {
@@ -26,11 +26,8 @@ class ApplierTest {
         val schema = mockk<ParsedSchema>()
         val subject = Subject("foo", null, schema)
 
-        val diff = Diffing.Result(incompatible = listOf(subject))
-
-        assertThrows<IllegalStateException> {
-            stateApplier.apply(diff)
-        }
+        val diff = Diffing.Result(incompatible = listOf(Diffing.CompatibilityTestResult(subject, listOf("error!"))))
+        assertEquals(Result.ERROR, stateApplier.apply(diff))
     }
 
     @Test

--- a/src/test/kotlin/dev/domnikl/schemaregistrygitops/state/DiffingTest.kt
+++ b/src/test/kotlin/dev/domnikl/schemaregistrygitops/state/DiffingTest.kt
@@ -28,9 +28,9 @@ class DiffingTest {
         val result = diff.diff(state)
 
         assertEquals(Diffing.Change(Compatibility.NONE, Compatibility.BACKWARD), result.compatibility)
-        assertEquals(emptyList<Subject>(), result.incompatible)
+        assertEquals(emptyList<Diffing.CompatibilityTestResult>(), result.incompatible)
         assertEquals(emptyList<Subject>(), result.added)
-        assertEquals(emptyList<Subject>(), result.deleted)
+        assertEquals(emptyList<String>(), result.deleted)
         assertEquals(emptyList<Diffing.Changes>(), result.modified)
     }
 
@@ -39,11 +39,11 @@ class DiffingTest {
         val state = State(Compatibility.BACKWARD, listOf(subject))
 
         every { client.subjects() } returns listOf("foobar")
-        every { client.testCompatibility(any()) } returns false
+        every { client.testCompatibility(any()) } returns listOf("incompatible!")
 
         val result = diff.diff(state)
 
-        assertEquals(listOf(subject), result.incompatible)
+        assertEquals(listOf(Diffing.CompatibilityTestResult(subject, listOf("incompatible!"))), result.incompatible)
         assertEquals(emptyList<Subject>(), result.added)
         assertEquals(emptyList<Diffing.Changes>(), result.modified)
         assertEquals(emptyList<String>(), result.deleted)
@@ -54,11 +54,11 @@ class DiffingTest {
         val state = State(Compatibility.BACKWARD, listOf(subject))
 
         every { client.subjects() } returns emptyList()
-        every { client.testCompatibility(any()) } returns true
+        every { client.testCompatibility(any()) } returns emptyList()
 
         val result = diff.diff(state)
 
-        assertEquals(emptyList<Subject>(), result.incompatible)
+        assertEquals(emptyList<Diffing.CompatibilityTestResult>(), result.incompatible)
         assertEquals(listOf(subject), result.added)
         assertEquals(emptyList<Diffing.Changes>(), result.modified)
         assertEquals(emptyList<String>(), result.deleted)
@@ -72,7 +72,7 @@ class DiffingTest {
 
         val result = diff.diff(state, true)
 
-        assertEquals(emptyList<Subject>(), result.incompatible)
+        assertEquals(emptyList<Diffing.CompatibilityTestResult>(), result.incompatible)
         assertEquals(emptyList<Subject>(), result.added)
         assertEquals(emptyList<Diffing.Changes>(), result.modified)
         assertEquals(listOf("foobar"), result.deleted)
@@ -86,7 +86,7 @@ class DiffingTest {
 
         val result = diff.diff(state, false)
 
-        assertEquals(emptyList<Subject>(), result.incompatible)
+        assertEquals(emptyList<Diffing.CompatibilityTestResult>(), result.incompatible)
         assertEquals(emptyList<Subject>(), result.added)
         assertEquals(emptyList<Diffing.Changes>(), result.modified)
         assertEquals(emptyList<String>(), result.deleted)
@@ -100,14 +100,14 @@ class DiffingTest {
         every { client.subjects() } returns listOf("foobar")
         every { remoteSchema.canonicalString() } returns subject.schema.canonicalString()
         every { client.getLatestSchema("foobar") } returns remoteSchema
-        every { client.testCompatibility(any()) } returns true
+        every { client.testCompatibility(any()) } returns emptyList()
         every { client.compatibility("foobar") } returns Compatibility.BACKWARD_TRANSITIVE
 
         val result = diff.diff(state)
 
-        assertEquals(emptyList<Subject>(), result.incompatible)
+        assertEquals(emptyList<Diffing.CompatibilityTestResult>(), result.incompatible)
         assertEquals(emptyList<Subject>(), result.added)
-        assertEquals(emptyList<Subject>(), result.deleted)
+        assertEquals(emptyList<String>(), result.deleted)
         assertEquals(1, result.modified.size)
         assertEquals(
             Diffing.Changes(
@@ -130,15 +130,15 @@ class DiffingTest {
         every { client.getLatestSchema("bar") } returns remoteSchema
         every { client.version(subject) } returns null
         every { client.version(subject2) } returns null
-        every { client.testCompatibility(any()) } returns true
+        every { client.testCompatibility(any()) } returns emptyList()
         every { client.compatibility("foobar") } returns subject.compatibility!!
         every { client.compatibility("bar") } returns subject2.compatibility!!
 
         val result = diff.diff(state)
 
-        assertEquals(emptyList<Subject>(), result.incompatible)
+        assertEquals(emptyList<Diffing.CompatibilityTestResult>(), result.incompatible)
         assertEquals(emptyList<Subject>(), result.added)
-        assertEquals(emptyList<Subject>(), result.deleted)
+        assertEquals(emptyList<String>(), result.deleted)
         assertEquals(
             listOf(
                 Diffing.Changes(subject, null, Diffing.Change(remoteSchema, subject.schema)),
@@ -157,14 +157,14 @@ class DiffingTest {
         every { remoteSchema.canonicalString() } returns subject.schema.canonicalString()
         every { client.getLatestSchema("foobar") } returns remoteSchema
         every { client.version(subject) } returns 5
-        every { client.testCompatibility(any()) } returns true
+        every { client.testCompatibility(any()) } returns emptyList()
         every { client.compatibility("foobar") } returns subject.compatibility!!
 
         val result = diff.diff(state)
 
-        assertEquals(emptyList<Subject>(), result.incompatible)
+        assertEquals(emptyList<Diffing.CompatibilityTestResult>(), result.incompatible)
         assertEquals(emptyList<Subject>(), result.added)
-        assertEquals(emptyList<Subject>(), result.deleted)
+        assertEquals(emptyList<String>(), result.deleted)
         assertEquals(emptyList<Diffing.Changes>(), result.modified)
     }
 
@@ -176,14 +176,14 @@ class DiffingTest {
         every { client.subjects() } returns listOf("foobar")
         every { remoteSchema.canonicalString() } returns subject.schema.canonicalString()
         every { client.getLatestSchema("foobar") } returns remoteSchema
-        every { client.testCompatibility(any()) } returns true
+        every { client.testCompatibility(any()) } returns emptyList()
         every { client.compatibility("foobar") } returns subject.compatibility!!
 
         val result = diff.diff(state)
 
-        assertEquals(emptyList<Subject>(), result.incompatible)
+        assertEquals(emptyList<Diffing.CompatibilityTestResult>(), result.incompatible)
         assertEquals(emptyList<Subject>(), result.added)
-        assertEquals(emptyList<Subject>(), result.deleted)
+        assertEquals(emptyList<String>(), result.deleted)
         assertEquals(emptyList<Diffing.Changes>(), result.modified)
     }
 
@@ -196,14 +196,14 @@ class DiffingTest {
 
         every { client.subjects() } returns listOf("foobar")
         every { client.getLatestSchema("foobar") } returns schema
-        every { client.testCompatibility(any()) } returns true
+        every { client.testCompatibility(any()) } returns emptyList()
         every { client.compatibility("foobar") } returns subject.compatibility!!
 
         val result = diff.diff(state)
 
-        assertEquals(emptyList<Subject>(), result.incompatible)
+        assertEquals(emptyList<Diffing.CompatibilityTestResult>(), result.incompatible)
         assertEquals(emptyList<Subject>(), result.added)
-        assertEquals(emptyList<Subject>(), result.deleted)
+        assertEquals(emptyList<String>(), result.deleted)
         assertEquals(listOf(Diffing.Changes(subject, null, Diffing.Change(schema, changedSchema))), result.modified)
     }
 


### PR DESCRIPTION
This implements #100 to log incompatible changes as ERROR for `plan` and `apply` as well as change internals to not immediately throw an exception in the `Applier`, but log every error and return a Result enum.